### PR TITLE
Issue #3 - Import new _tree module for shap>= 0.36

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def main():
         name="shap4j-data-converter",
         version="0.0.2",
         description="Data converter for shap4j",
-        install_requires=['shap', 'numpy'],
+        install_requires=['shap', 'numpy==1.25'],
         packages=find_packages(),
         scripts=['bin/shap4jconv'],
 

--- a/shap4jconv/__init__.py
+++ b/shap4jconv/__init__.py
@@ -5,7 +5,7 @@ import ctypes
 import os.path
 
 import numpy as np
-from shap.explainers.tree import TreeEnsemble
+from shap.explainers._tree import TreeEnsemble
 
 
 INT_ARRAYS = ('children_left', 'children_right', 'children_default', 'features')


### PR DESCRIPTION
Tree module moved in shap 0.36 and became _tree
This makes it compatible with latest versions of shap